### PR TITLE
install .net core sdk 2.0.2 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ os:
   - linux
   - osx
 
+osx_image: xcode9
+
 mono:
   - weekly
   - latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ mono:
   - 4.8.0
   - 4.4.2
 
+dotnet: 2.0.2
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ mono:
   - 4.8.0
   - 4.4.2
 
-dotnet: 2.0.2
+dotnet: 2.0.0
 
 sudo: false
 


### PR DESCRIPTION
fix https://github.com/fsharp/FSharp.Compiler.Service/pull/833 installing .net core 2.0 prerequisites

travis build is in progress, let me check works ok: 

[![Build Status](https://travis-ci.org/enricosada/FSharp.Compiler.Service.svg?branch=dsyme-i1)](https://travis-ci.org/enricosada/FSharp.Compiler.Service)

it's building but is green